### PR TITLE
SPRING.ZIPKIN.BASEURL is no longer supported

### DIFF
--- a/04.docker/backup/docker-compose-05-zipkin.yaml
+++ b/04.docker/backup/docker-compose-05-zipkin.yaml
@@ -13,7 +13,7 @@ services:
       - naming-server
     environment:
       EUREKA.CLIENT.SERVICEURL.DEFAULTZONE: http://naming-server:8761/eureka
-      SPRING.ZIPKIN.BASEURL: http://zipkin-server:9411/
+      MANAGEMENT.ZIPKIN.TRACING.ENDPOINT: http://zipkin-server:9411/api/v2/spans
 
   currency-conversion:
     image: in28min/mmv2-currency-conversion-service:0.0.1-SNAPSHOT
@@ -26,7 +26,7 @@ services:
       - naming-server
     environment:
       EUREKA.CLIENT.SERVICEURL.DEFAULTZONE: http://naming-server:8761/eureka
-      SPRING.ZIPKIN.BASEURL: http://zipkin-server:9411/
+      MANAGEMENT.ZIPKIN.TRACING.ENDPOINT: http://zipkin-server:9411/api/v2/spans
 
   api-gateway:
     image: in28min/mmv2-api-gateway:0.0.1-SNAPSHOT
@@ -39,7 +39,7 @@ services:
       - naming-server
     environment:
       EUREKA.CLIENT.SERVICEURL.DEFAULTZONE: http://naming-server:8761/eureka
-      SPRING.ZIPKIN.BASEURL: http://zipkin-server:9411/
+      MANAGEMENT.ZIPKIN.TRACING.ENDPOINT: http://zipkin-server:9411/api/v2/spans
 
   naming-server:
     image: in28min/mmv2-naming-server:0.0.1-SNAPSHOT


### PR DESCRIPTION
spring.zipkin.baseurl is not working for spring-boot version 3.0.2.